### PR TITLE
DOCS: fix rtd install

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,6 +18,9 @@ sphinx:
 # building the python
 python:
   install:
+    - method: pip
+      path: ./Python
+      editable: true
     - requirements: docs/docs_requirements.txt
 
 # We recommend specifying your dependencies to enable reproducible builds:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation build configuration to install the local Python package in editable mode during the Read the Docs build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->